### PR TITLE
update from mongo-java-driver:3.8.1 to  mongodb-driver-sync:5.2.1

### DIFF
--- a/NOTICE_GEM
+++ b/NOTICE_GEM
@@ -11,5 +11,5 @@ They are licensed under the Apache Software License, Version 2.0.
 The gem distribution of this product includes JARs of the Jakarta Bean Validation API 1.1 (https://beanvalidation.org/1.1/), as-is.
 It is licensed under the Apache Software License, Version 2.0.
 
-The gem distribution of this product includes a JAR of MongoDB Java Driver (https://mongodb.github.io/mongo-java-driver/), as-is.
+The gem distribution of this product includes a JAR of mongo-java-driver (https://github.com/mongodb/mongo-java-driver), as-is.
 It is licensed under the Apache Software License, Version 2.0.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This plugin loads documents as single-column records (column name is "record"). 
 
 ## Overview
 
-This plugin only works with embulk >= 0.8.8.
+This plugin only works with embulk >= 0.8.8 and MongoDB 4.0 to 8.0 (See [MongoDB Java Driver Version 5.2 Compatibility](https://www.mongodb.com/docs/drivers/java/sync/v5.2/compatibility/))
 
 * **Plugin type**: input
 * **Guess supported**: no
@@ -21,7 +21,7 @@ This plugin only works with embulk >= 0.8.8.
     - **uri**: [MongoDB connection string URI](https://docs.mongodb.org/manual/reference/connection-string/) (e.g. 'mongodb://localhost:27017/mydb') (string, required)
   - use separated URI parameters
     - **hosts**: list of hosts. `hosts` are pairs of host(string, required) and port(integer, optional, default: 27017)
-    - **auth_method**: Auth method. One of `scram-sha-1`, `mongodb-cr`, `auto` (string, optional, default: null)
+    - **auth_method**: Auth method. One of `scram-sha-256`, `scram-sha-1`, `auto` (string, optional, default: `auto`)
     - **auth_source**: Auth source. The database name where the user is defined (string, optional, default: null)
     - **user**: (string, optional)
     - **password**:  (string, optional)
@@ -69,11 +69,14 @@ in:
   collection: "my_collection"
 ```
 
-If you set `auth_method: auto`, The client will negotiate the best mechanism based on the version of the server that the client is authenticating to.
+If you set `auth_method: auto`, the [default authentication mechanism](https://www.mongodb.com/docs/drivers/java/sync/v5.2/fundamentals/auth/#std-label-default-auth-mechanism) setting uses one of the following authentication mechanisms depending on what your version of MongoDB Server supports:
 
-If the server version is 3.0 or higher, the driver will authenticate using the SCRAM-SHA-1 mechanism.
+1. SCRAM-SHA-256
+2. SCRAM-SHA-1
+3. MONGODB-CR
 
-Otherwise, the driver will authenticate using the MONGODB_CR mechanism. 
+[MONGODB-CR](https://www.mongodb.com/docs/drivers/java/sync/v5.2/fundamentals/auth/#mongodb-cr) was deprecated starting in MongoDB 3.6 and is no longer supported as of MongoDB 4.0.
+You cannot specify this method explicitly; refer to the fallback provided by the `auto` to connect using MONGODB-CR.
 
 #### Use URI String
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ java {
 dependencies {
     compileOnly "org.embulk:embulk-api:0.10.31"
     compileOnly "org.embulk:embulk-spi:0.10.31"
-    compile "org.mongodb:mongo-java-driver:3.8.1"
+    compile "org.mongodb:mongodb-driver-sync:5.2.1"
 
     compile("org.embulk:embulk-util-config:0.3.1") {
         // They conflict with embulk-core. They are once excluded here,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 services:
   mongodb:
     container_name: embulk-input-mongodb_server
-    image: mongo:3.6
+    image: mongo:7.0.4
     restart: always
     ports:
     - 27017:27017
@@ -30,14 +30,14 @@ services:
 
   mongoClientTemp:
     container_name: mongoClientTemp
-    image: mongo:3.6
+    image: mongo:7.0.4
     depends_on:
     - mongodb
     # Sleep to wait MongoDB wake up on Travis CI
     command: >
       /bin/bash -c
       "sleep 15 &&
-      mongo --host mongodb -u admin -p tiger admin --eval \"db.getSiblingDB('mydb').createUser({user:'mongo_user', pwd:'dbpass', roles:[{role:'readWrite',db:'mydb'}]});\""
+      mongosh --host mongodb -u admin -p tiger admin --eval \"db.getSiblingDB('mydb').createUser({user:'mongo_user', pwd:'dbpass', roles:[{role:'readWrite',db:'mydb'}]});\""
 volumes:
   mongodb-data:
     driver: local

--- a/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -7,4 +7,7 @@ com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
 org.embulk:embulk-util-config:0.3.1
-org.mongodb:mongo-java-driver:3.8.1
+org.mongodb:bson-record-codec:5.2.1
+org.mongodb:bson:5.2.1
+org.mongodb:mongodb-driver-core:5.2.1
+org.mongodb:mongodb-driver-sync:5.2.1

--- a/src/main/java/org/embulk/input/mongodb/AuthMethod.java
+++ b/src/main/java/org/embulk/input/mongodb/AuthMethod.java
@@ -26,7 +26,7 @@ public enum AuthMethod
 {
     AUTO,
     SCRAM_SHA_1,
-    MONGODB_CR;
+    SCRAM_SHA_256;
 
     @JsonValue
     @Override
@@ -39,10 +39,10 @@ public enum AuthMethod
     public static AuthMethod fromString(String value)
     {
         switch (value.replace("_", "-")) {
+            case "scram-sha-256":
+                return SCRAM_SHA_256;
             case "scram-sha-1":
                 return SCRAM_SHA_1;
-            case "mongodb-cr":
-                return MONGODB_CR;
             case "auto":
                 return AUTO;
             default:

--- a/src/test/java/org/embulk/input/mongodb/AssertUtil.java
+++ b/src/test/java/org/embulk/input/mongodb/AssertUtil.java
@@ -1,0 +1,17 @@
+package org.embulk.input.mongodb;
+
+import org.hamcrest.Matcher;
+
+public class AssertUtil
+{
+    private AssertUtil()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @SuppressWarnings("deprecation")
+    public static <T> void assertThat(T actual, Matcher<? super T> matcher)
+    {
+        org.junit.Assert.assertThat(actual, matcher);
+    }
+}

--- a/src/test/java/org/embulk/input/mongodb/Pages.java
+++ b/src/test/java/org/embulk/input/mongodb/Pages.java
@@ -16,15 +16,16 @@
 
 package org.embulk.input.mongodb;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
 import org.embulk.spi.Column;
 import org.embulk.spi.ColumnVisitor;
 import org.embulk.spi.Page;
 import org.embulk.spi.PageReader;
 import org.embulk.spi.Schema;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
 
 class Pages
 {
@@ -38,6 +39,7 @@ class Pages
         return toObjects(schema, pages, false);
     }
 
+    @SuppressWarnings("deprecation") // new PageReader(schema)
     private static List<Object[]> toObjects(final Schema schema, final Iterable<Page> pages, final boolean useInstant)
     {
         final ArrayList<Object[]> builder = new ArrayList<>();

--- a/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
+++ b/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import com.mongodb.MongoClientOptions;
-import com.mongodb.MongoClientURI;
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCredential;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
@@ -46,6 +46,7 @@ import org.embulk.spi.Schema;
 import org.embulk.spi.TestPageBuilderReader.MockPageOutput;
 import org.embulk.spi.type.Types;
 import org.embulk.util.config.ConfigMapperFactory;
+import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -65,7 +66,6 @@ import java.util.TimeZone;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class TestMongodbInputPlugin
 {
@@ -77,6 +77,7 @@ public class TestMongodbInputPlugin
     @Rule
     public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
 
+    @SuppressWarnings("deprecation")
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
@@ -191,6 +192,22 @@ public class TestMongodbInputPlugin
     }
 
     @Test
+    public void testCreateCredentialsSha256() throws Exception
+    {
+        final PluginTask task = CONFIG_MAPPER_FACTORY.createConfigMapper().map(
+                configForAuth().deepCopy()
+                        .set("auth_method", "scram-sha-256")
+                        .set("database", "db"),
+                PluginTask.class);
+
+        Method createCredential = MongodbInputPlugin.class.getDeclaredMethod("createCredential", PluginTask.class);
+        createCredential.setAccessible(true);
+        MongoCredential credential = (MongoCredential) createCredential.invoke(plugin, task);
+        assertThat("SCRAM-SHA-256", is(credential.getMechanism()));
+        assertThat("db", is(credential.getSource()));
+    }
+
+    @Test
     public void testCreateCredentialsSha1() throws Exception
     {
         final PluginTask task = CONFIG_MAPPER_FACTORY.createConfigMapper().map(
@@ -223,7 +240,7 @@ public class TestMongodbInputPlugin
         assertThat("authdb", is(credential.getSource()));
     }
 
-    @Test
+    @Test(expected = ConfigException.class)
     public void testCreateCredentialsCr() throws Exception
     {
         final PluginTask task = CONFIG_MAPPER_FACTORY.createConfigMapper().map(
@@ -238,46 +255,46 @@ public class TestMongodbInputPlugin
     }
 
     @Test
-    public void testCreateMongoClientOptionsTLSEnableWithInsecureEnable() throws Exception
+    public void testCreateMongoClientSettingsTLSEnableWithInsecureEnable() throws Exception
     {
         final PluginTask task = CONFIG_MAPPER_FACTORY.createConfigMapper().map(
                 configForAuth().deepCopy()
                         .set("tls", "true")
                         .set("tls_insecure", "true"),
                 PluginTask.class);
-        Method createMongoClientOptions = MongodbInputPlugin.class.getDeclaredMethod("createMongoClientOptions", PluginTask.class);
-        createMongoClientOptions.setAccessible(true);
-        MongoClientOptions mongoClientOptions = (MongoClientOptions) createMongoClientOptions.invoke(plugin, task);
-        assertThat(true, is(mongoClientOptions.isSslEnabled()));
-        assertThat(true, is(mongoClientOptions.isSslInvalidHostNameAllowed()));
+        Method createMongoClientSettings = MongodbInputPlugin.class.getDeclaredMethod("createMongoClientSettings", PluginTask.class);
+        createMongoClientSettings.setAccessible(true);
+        MongoClientSettings mongoClientSettings = (MongoClientSettings) createMongoClientSettings.invoke(plugin, task);
+        assertThat(true, is(mongoClientSettings.getSslSettings().isEnabled()));
+        assertThat(true, is(mongoClientSettings.getSslSettings().isInvalidHostNameAllowed()));
     }
 
     @Test
-    public void testCreateMongoClientOptionsTLSEnableWithInsecureDisable() throws Exception
+    public void testCreateMongoClientSettingsTLSEnableWithInsecureDisable() throws Exception
     {
         final PluginTask task = CONFIG_MAPPER_FACTORY.createConfigMapper().map(
                 configForAuth().deepCopy()
                         .set("tls", "true"),
                 PluginTask.class);
-        Method createMongoClientOptions = MongodbInputPlugin.class.getDeclaredMethod("createMongoClientOptions", PluginTask.class);
-        createMongoClientOptions.setAccessible(true);
-        MongoClientOptions mongoClientOptions = (MongoClientOptions) createMongoClientOptions.invoke(plugin, task);
-        assertThat(true, is(mongoClientOptions.isSslEnabled()));
-        assertThat(false, is(mongoClientOptions.isSslInvalidHostNameAllowed()));
+        Method createMongoClientSettings = MongodbInputPlugin.class.getDeclaredMethod("createMongoClientSettings", PluginTask.class);
+        createMongoClientSettings.setAccessible(true);
+        MongoClientSettings mongoClientSettings = (MongoClientSettings) createMongoClientSettings.invoke(plugin, task);
+        assertThat(true, is(mongoClientSettings.getSslSettings().isEnabled()));
+        assertThat(false, is(mongoClientSettings.getSslSettings().isInvalidHostNameAllowed()));
     }
 
     @Test
-    public void testCreateMongoClientOptionsTLSDisable() throws Exception
+    public void testCreateMongoClientSettingsTLSDisable() throws Exception
     {
         final PluginTask task = CONFIG_MAPPER_FACTORY.createConfigMapper().map(
                 configForAuth().deepCopy()
                         .set("tls", "false"),
                 PluginTask.class);
-        Method createMongoClientOptions = MongodbInputPlugin.class.getDeclaredMethod("createMongoClientOptions", PluginTask.class);
-        createMongoClientOptions.setAccessible(true);
-        MongoClientOptions mongoClientOptions = (MongoClientOptions) createMongoClientOptions.invoke(plugin, task);
-        assertThat(false, is(mongoClientOptions.isSslEnabled()));
-        assertThat(false, is(mongoClientOptions.isSslInvalidHostNameAllowed()));
+        Method createMongoClientSettings = MongodbInputPlugin.class.getDeclaredMethod("createMongoClientSettings", PluginTask.class);
+        createMongoClientSettings.setAccessible(true);
+        MongoClientSettings mongoClientSettings = (MongoClientSettings) createMongoClientSettings.invoke(plugin, task);
+        assertThat(false, is(mongoClientSettings.getSslSettings().isEnabled()));
+        assertThat(false, is(mongoClientSettings.getSslSettings().isInvalidHostNameAllowed()));
     }
 
     @Test
@@ -300,7 +317,9 @@ public class TestMongodbInputPlugin
     {
         final PluginTask task = CONFIG_MAPPER_FACTORY.createConfigMapper().map(config, PluginTask.class);
         Schema schema = getFieldSchema();
-        plugin.cleanup(task.dump(), schema, 0, Lists.<TaskReport>newArrayList()); // no errors happens
+        @SuppressWarnings("deprecation") // task.dump
+        TaskSource dump = task.dump();
+        plugin.cleanup(dump, schema, 0, Lists.<TaskReport>newArrayList()); // no errors happens
     }
 
     @Test
@@ -360,14 +379,14 @@ public class TestMongodbInputPlugin
     @Test
     public void testRunWithConnectionParams() throws Exception
     {
-        MongoClientURI uri = new MongoClientURI(mongoUri);
-        String host = uri.getHosts().get(0);
+        ConnectionString connectionString = new ConnectionString(mongoUri);
+        String host = connectionString.getHosts().get(0);
         Integer port = (host.split(":")[1] != null) ? Integer.valueOf(host.split(":")[1]) : 27017;
         ConfigSource config = CONFIG_MAPPER_FACTORY.newConfigSource()
                 .set("hosts", Arrays.asList(ImmutableMap.of("host", host.split(":")[0], "port", port)))
-                .set("user", uri.getUsername())
-                .set("password", uri.getPassword())
-                .set("database", uri.getDatabase())
+                .set("user", connectionString.getUsername())
+                .set("password", connectionString.getPassword())
+                .set("database", connectionString.getDatabase())
                 .set("collection", mongoCollection);
         final PluginTask task = CONFIG_MAPPER_FACTORY.createConfigMapper().map(config, PluginTask.class);
 
@@ -521,7 +540,7 @@ public class TestMongodbInputPlugin
     }
 
     @Test
-    public void testNormlizeWithIdFieldName() throws Exception
+    public void testNormalizeWithIdFieldName() throws Exception
     {
         ConfigSource config = config().set("id_field_name", "object_id");
 
@@ -813,7 +832,7 @@ public class TestMongodbInputPlugin
         Method method = MongodbInputPlugin.class.getDeclaredMethod("connect", PluginTask.class);
         method.setAccessible(true);
         MongoDatabase db = (MongoDatabase) method.invoke(plugin, task);
-        MongoCollection collection = db.getCollection(collectionName);
+        MongoCollection<Document> collection = db.getCollection(collectionName);
         collection.drop();
     }
 
@@ -822,7 +841,7 @@ public class TestMongodbInputPlugin
         Method method = MongodbInputPlugin.class.getDeclaredMethod("connect", PluginTask.class);
         method.setAccessible(true);
         MongoDatabase db = (MongoDatabase) method.invoke(plugin, task);
-        MongoCollection collection = db.getCollection(task.getCollection());
+        MongoCollection<Document> collection = db.getCollection(task.getCollection());
         collection.insertMany(documents);
     }
 
@@ -831,5 +850,11 @@ public class TestMongodbInputPlugin
       DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", java.util.Locale.ENGLISH);
       dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
       return dateFormat;
+    }
+
+    @SuppressWarnings("deprecation")
+    public static <T> void assertThat(T actual, Matcher<? super T> matcher)
+    {
+        org.junit.Assert.assertThat(actual, matcher);
     }
 }

--- a/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
+++ b/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
@@ -46,7 +46,6 @@ import org.embulk.spi.Schema;
 import org.embulk.spi.TestPageBuilderReader.MockPageOutput;
 import org.embulk.spi.type.Types;
 import org.embulk.util.config.ConfigMapperFactory;
-import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -64,6 +63,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.TimeZone;
 
+import static org.embulk.input.mongodb.AssertUtil.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 
@@ -850,11 +850,5 @@ public class TestMongodbInputPlugin
       DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", java.util.Locale.ENGLISH);
       dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
       return dateFormat;
-    }
-
-    @SuppressWarnings("deprecation")
-    public static <T> void assertThat(T actual, Matcher<? super T> matcher)
-    {
-        org.junit.Assert.assertThat(actual, matcher);
     }
 }


### PR DESCRIPTION
- update mongodb-java-driver to the latest version
    - support MongoDB 4.0 to 8.0
    - support SCRAM-SHA-256 auth and unsupport MONGODB-CR auth
- refactoring
    - suppress deprecation warnings
    - fix checkstyle warning
    - fix typo