### PR TITLE
build ジョブに JDK 8 セットアップを追加

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,11 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || contains(github.ref, 'refs/tags/') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up JDK 8
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: 8
+          distribution: "zulu"
       - name: Set up Ruby 2.7
         uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a # v1.302.0
         with:


### PR DESCRIPTION
## Summary
- `build` ジョブには `setup-java` が無く、`push gem` ステップが runner デフォルト JDK (21) で `./gradlew` を実行していた
- Gradle 6.2.2 同梱の Groovy 2.5 は JDK 16+ で `jdk.internal.*` へのリフレクションが塞がれ `NoClassDefFoundError: org.codehaus.groovy.vmplugin.v7.Java7` で初期化失敗
- `test` ジョブと同じ zulu JDK 8 セットアップを追加して解消

参考: https://github.com/trocco-io/embulk-input-mongodb/actions/runs/24543614502/job/71754567745

## Test plan
- [ ] タグを push して `build` ジョブが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)