### PR TITLE
バージョンタグのパターンを拡張

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,8 @@ group = "io.trocco"
 description = "Loads records from Mongodb."
 version = {
     def vd = versionDetails()
-    if (vd.commitDistance == 0 && vd.lastTag ==~ /^[0-9]+\.[0-9]+\.[0-9]+(\.[a-zA-Z0-9]+)?/) {
-        vd.lastTag
+    if (vd.commitDistance == 0 && vd.lastTag ==~ /^v?[0-9]+\.[0-9]+\.[0-9]+(\.[a-zA-Z0-9-]+)*$/) {
+        vd.lastTag.replaceFirst(/^v/, "")
     } else {
         "0.0.0.${vd.gitHash}"
     }


### PR DESCRIPTION
## Summary
- `build.gradle` のタグ判定正規表現を拡張
  - 先頭の `v` prefix を許容 (gem version としては `replaceFirst` で除去)
  - サフィックスに `-` と複数のドット区切りセグメントを許容
- 例: `v0.7.0.trocco.0.0.1-pre.drv` が正しくバージョンとして認識される

## Test plan
- [ ] 対象タグを push して `./gradlew printVersion` が `0.7.0.trocco.0.0.1-pre.drv` を返すことを確認
- [ ] `./gradlew gem` が成功し gem ファイル名にバージョンが反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)