### PR TITLE
check__pinact workflow を追加

### DIFF
--- a/.github/workflows/check__pinact.yml
+++ b/.github/workflows/check__pinact.yml
@@ -1,0 +1,27 @@
+name: check__pinact
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**/*"
+      - ".github/actions/**/*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pinact:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Pin actions
+        uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
+        with:
+          app_id: ${{ secrets.PINACT_GITHUB_APP_ID }}
+          app_private_key: ${{ secrets.PINACT_GITHUB_APP_PRIVATE_KEY }}


### PR DESCRIPTION
  ## Summary
  - `check__pinact` workflow を追加
  - GitHub Actions の workflow / composite action を変更した PR で pinact を実行する
  - `PINACT_GITHUB_APP_ID` / `PINACT_GITHUB_APP_PRIVATE_KEY` を使って `uses:` の SHA pinning を自動化す
  る

  ## Test plan
  - workflow ファイルを変更する PR で `check__pinact` が起動することを確認
  - pinning 対象の `uses:` を含む変更で pinact が動作することを確認